### PR TITLE
[D2G] Metrik Kompilieren hinzugefügt

### DIFF
--- a/scripts/metrics/compile.sh
+++ b/scripts/metrics/compile.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DIR=build/results
+
+if [ ! -d "$DIR" ]
+then
+    mkdir -p "$DIR"
+fi
+
+gradle compileJava
+echo "result: $?" > "$DIR/compile.yml"
+

--- a/scripts/metrics/compile.sh
+++ b/scripts/metrics/compile.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Wrapper for executing "gradle compileJava". Make sure to execute
+# the script inside a task folder that contains a gradle project.
+# The return value of the gradle execution is saved in a file
+# "build/results/compile.yml".
+#
+# usage: compile.sh
+#
+# This script is step 5 in the Deploy-to-Grading pipeline that is
+# executed for every task that includes the compile metric.
+#
+
 DIR=build/results
 
 usage() {

--- a/scripts/metrics/compile.sh
+++ b/scripts/metrics/compile.sh
@@ -13,14 +13,6 @@
 
 DIR=build/results
 
-usage() {
-    # Print usage information
-    cat <<EOM
-usage: ./$(basename $0)
-  Runs gradle to compile the java code and saves the results.
-EOM
-}
-
 if [ ! -d "$DIR" ]
 then
     mkdir -p "$DIR"

--- a/scripts/metrics/compile.sh
+++ b/scripts/metrics/compile.sh
@@ -2,6 +2,14 @@
 
 DIR=build/results
 
+usage() {
+    # Print usage information
+    cat <<EOM
+usage: ./$(basename $0)
+  Runs gradle to compile the java code and saves the results.
+EOM
+}
+
 if [ ! -d "$DIR" ]
 then
     mkdir -p "$DIR"

--- a/scripts/metrics/compile.sh
+++ b/scripts/metrics/compile.sh
@@ -7,6 +7,6 @@ then
     mkdir -p "$DIR"
 fi
 
-gradle compileJava
+./gradlew compileJava
 echo "result: $?" > "$DIR/compile.yml"
 

--- a/scripts/metrics/compile_eval.py
+++ b/scripts/metrics/compile_eval.py
@@ -1,0 +1,64 @@
+#!/bin/python3
+
+import os
+import sys
+import yaml
+
+RESULTS_DIR = "build/results/"
+RESULT_FILE = "compile.yml"
+
+def _print_usage():
+    print("usage: compile_eval.py [taskname(optional)]")
+    print("       Make sure that compile.sh was executed prior to this")
+    print("       script and that the task yaml was loaded correctly.")
+    exit(-1)
+
+def _load_generated_results():
+    # Loads the file build/results/compile.yml that contains the results
+    # of the compilation and return them.
+    try:
+        with open(RESULTS_DIR+RESULT_FILE, "r") as file:
+            try:
+                return yaml.safe_load(file)
+            except:
+                print("Invalid yaml file")
+                _print_usage()
+    except FileNotFoundError as err:
+        print("File %s not found" % RESULTS_DIR+RESULT_FILE)
+        _print_usage()
+
+def _generate_final_results(data, taskname):
+    # Generates a results dictionary as defined in d2g_procedure.md in the
+    # documentation and returns it. Requires the *TASKNAME*_METRICS_COMPILE_POINTS
+    # environment variable to be set.
+    points = int(os.environ["%s_METRICS_COMPILE_POINTS" % taskname.upper()])
+    results = {
+        "points": points if data["result"] == 0 else 0,
+        "max_points": points
+    }
+
+    if data["result"] != 0:
+        results["mistakes"] = [
+            {
+                "deduction": points,
+                "description": "Compiltion failed."
+            }
+        ]
+
+    return results
+
+def _print_results(results):
+    # Prints results to the console as yaml.
+    print(yaml.dump(results), end="")
+
+def _main():
+    taskname = "task"
+    if sys.argv == 2:
+        taskname = sys.argv[1]
+
+    data = _load_generated_results()
+    results = _generate_final_results(data, taskname)
+    _print_results(results)    
+
+if __name__ == "__main__":
+    _main()

--- a/scripts/metrics/compile_eval.py
+++ b/scripts/metrics/compile_eval.py
@@ -11,6 +11,9 @@ def _print_usage():
     print("usage: compile_eval.py [taskname(optional)]")
     print("       Make sure that compile.sh was executed prior to this")
     print("       script and that the task yaml was loaded correctly.")
+    print("")
+    print("       Params:")
+    print("       taskname    Prefix of the tasks used for env variables.")
     exit(-1)
 
 def _load_generated_results():

--- a/scripts/metrics/compile_eval.py
+++ b/scripts/metrics/compile_eval.py
@@ -13,7 +13,7 @@ def _print_usage():
     print("       script and that the task yaml was loaded correctly.")
     print("")
     print("       Params:")
-    print("       taskname    Prefix of the tasks used for env variables.")
+    print("       taskname    Prefix of the task used for env variables.")
     exit(-1)
 
 def _load_generated_results():

--- a/scripts/metrics/compile_eval.py
+++ b/scripts/metrics/compile_eval.py
@@ -20,8 +20,8 @@
 #   %TASKNAME%_METRICS_COMPILE_POINTS environment variable is not
 #   set or the results file was not found or could not be parsed.
 #
-# This script is step 6 in the Deploy-to-Grading pipeline that is
-# executed for every task that includes the junit metric.
+# This script is part of step 6 in the Deploy-to-Grading pipeline that
+# is executed for every task that includes the junit metric.
 #
 
 import os

--- a/scripts/metrics/compile_eval.py
+++ b/scripts/metrics/compile_eval.py
@@ -1,5 +1,29 @@
 #!/bin/python3
 
+# Evaluates the compile results. It is required to execute compile.sh
+# prior to the execution of this script. This script parses the results
+# saved in "build/results/junit/xml" and converts them into the "results.yml"
+# format defined in the 
+# [documentation](https://github.com/Programmiermethoden/Deploy-to-Grading/blob/master/doc/design_document/d2g_procedure.md#format-der-result.yml).
+# The output is printed to the console. Make sure to execute the script
+# inside a task folder and that the task configuration defined in a
+# task.yml file was loaded correctly using the load_yaml scripts.
+#
+# usage: compile_eval.py [taskname(optional)]
+#   Params:
+#   taskname    Name of the task used as prefix for the env variables.
+#               If no taskname is given, "task" is used as the default
+#               value.
+#
+# Error handling:
+# - Exits with an error code when the 
+#   %TASKNAME%_METRICS_COMPILE_POINTS environment variable is not
+#   set or the results file was not found or could not be parsed.
+#
+# This script is step 6 in the Deploy-to-Grading pipeline that is
+# executed for every task that includes the junit metric.
+#
+
 import os
 import sys
 import yaml
@@ -14,7 +38,6 @@ def _print_usage():
     print("")
     print("       Params:")
     print("       taskname    Prefix of the task used for env variables.")
-    exit(-1)
 
 def _load_generated_results():
     # Loads the file build/results/compile.yml that contains the results
@@ -26,9 +49,11 @@ def _load_generated_results():
             except:
                 print("Invalid yaml file")
                 _print_usage()
+                exit(-1)
     except FileNotFoundError as err:
         print("File %s not found" % RESULTS_DIR+RESULT_FILE)
         _print_usage()
+        exit(-1)
 
 def _generate_final_results(data, taskname):
     # Generates a results dictionary as defined in d2g_procedure.md in the


### PR DESCRIPTION
Closes #55 

- [X] Skript zum Ausführen der Compile-Metrik
- [x] Skript zum Auswerten der Ergebnisse der Compile-Metrik.

Das erste Skript ist aktuell ein Bash-Skript, welches "gradle compileJava" ausführt und den Rückgabewert in einer Yaml-Datei speichert. Hier wäre es auch möglich, das als Makefile umzusetzen. Nur ist das schlau im Hinblick auf die Erweiterbarkeit (Wenn wir viele Metriken haben, dann wird es eine sehr unübersichtliche Datei)? Wir brauchen übrigens ein Skript/Command als Zwischenschritt, um von der Metrik zu einem konkreten Befehl zu übersetzen (hier "compile" -> "compileJava") (und hier auch zum Speichern der Ergebnisse).