### PR TITLE
[GitHub] GitHub Action konfiguriert

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,20 @@
+name: 'Deploy-to-Grading'
+description: 'This action will setup and execute the Deploy-to-Grading pipeline.'
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Run Deploy-to-Grading
+      run: python3 ${{ github.action_path }}/scripts/deploy_to_grading.py
+      env: 
+        D2G_PATH: ${{ github.action_path }}
+      shell: bash
+    - name: Upload results
+      uses: actions/upload-artifact@v3
+      with:
+        name: D2G_results
+        path: results/


### PR DESCRIPTION
Closes #28.

Fügt eine `action.yml`-Datei hinzu, um Deploy-to-Grading als GH Action nutzbar zu machen.