### PR TITLE
[D2G] Konkrete Punkteanzahl bei JUnit-Tests hinzugefügt

### DIFF
--- a/scripts/metrics/junit_eval.py
+++ b/scripts/metrics/junit_eval.py
@@ -26,10 +26,11 @@
 
 import metric_utils
 import os
+import re
 
 RESULT_PATH = "build/results/junit/xml"
 
-POINTS_PER_TEST_ENV_KEY = "%s_METRICS_JUNIT_POINTS_PER_TEST"
+DEFAULT_POINTS_ENV_KEY = "%s_METRICS_JUNIT_DEFAULT_POINTS"
 
 USAGE = """usage: junit_eval.py [taskname(optional)]
        Make sure that junit.sh was executed prior to this
@@ -48,23 +49,33 @@ def _load_xml_files():
                 os.path.join(RESULT_PATH, file), USAGE))
     return data
 
-def _count_tests(data):
-    # Summarizes the overall number of tests and the number
-    # of failed tests. Returns a tuple (tests, failed_tests).
-    tests = 0
-    failed_tests = 0
+def _get_points_of_test(testname, default_points):
+    # Determines the possible points of a test case based on its name.
+    # It is possible to give tests a custom number of points by
+    # appending "_%POINTS%p" to the name of the test where %POINTS%
+    # is replaced with an integer value.
+    match = re.search(r"_\d+[pP]$", testname)
+    if match:
+        return match.group(0)[1:-1]
+    return default_points
+
+def _get_points(data, default_points):
+    points = 0
+    max_points = 0
 
     for testsuite in data:
         root = testsuite.getroot()
-        # Note: Skipped tests are not counted towards either
-        #       of those values.
-        tests = int(root.attrib["tests"])
-        failed_tests = int(root.attrib["failures"]) \
-                     + int(root.attrib["errors"])
+        for testcase in root:
+            if testcase.tag == "testcase":
+                possible_points = _get_points_of_test(testcase.attrib["name"],
+                                                      default_points)
+                if len(testcase) == 0:
+                    points += possible_points
+                max_points += possible_points
     
-    return (tests, failed_tests)
+    return (points, max_points)
 
-def _summarize_mistakes(data, points_per_test):
+def _summarize_mistakes(data, default_points):
     # Collect all failed test cases and create a summery containing
     # the deduction and a description of the error.
     mistakes = []
@@ -75,7 +86,8 @@ def _summarize_mistakes(data, points_per_test):
                 description = "%s::%s: %s" % (root.attrib["name"], \
                     testcase.attrib["name"], testcase[0].attrib["message"])
                 mistakes.append({
-                    "deduction": points_per_test,
+                    "deduction": _get_points_of_test(testcase.attrib["name"],
+                                                     default_points),
                     "description": description
                 })
 
@@ -85,13 +97,13 @@ def _main():
     taskname = metric_utils.get_taskname()
 
     data = _load_xml_files()
-    points_per_test = int(metric_utils.get_env_variable(
-        POINTS_PER_TEST_ENV_KEY, taskname, USAGE))
-    test_count = _count_tests(data)
-    mistakes = _summarize_mistakes(data, points_per_test)
+    default_points = int(metric_utils.get_env_variable(
+        DEFAULT_POINTS_ENV_KEY, taskname, USAGE))
+    points, max_points = _get_points(data, default_points)
+    mistakes = _summarize_mistakes(data, default_points)
 
-    results = metric_utils.generate_final_results_points_per_test(
-        mistakes, test_count, points_per_test)
+    results = metric_utils._generate_final_results(
+        mistakes, points, max_points)
     metric_utils.print_results(results)
 
 if __name__ == "__main__":

--- a/scripts/metrics/junit_eval.py
+++ b/scripts/metrics/junit_eval.py
@@ -56,7 +56,7 @@ def _get_points_of_test(testname, default_points):
     # is replaced with an integer value.
     match = re.search(r"_\d+[pP]$", testname)
     if match:
-        return match.group(0)[1:-1]
+        return int(match.group(0)[1:-1])
     return default_points
 
 def _get_points(data, default_points):

--- a/scripts/metrics/metric_utils.py
+++ b/scripts/metrics/metric_utils.py
@@ -129,8 +129,10 @@ def generate_final_results_all_or_nothing(result, points, error_description):
                 "deduction": points,
                 "description": error_description
             }
-        ]
-
+       ]
+    
+    # Note: We do not use the default function here as we don't want that the
+    # "mistakes" variable is defined in the final dictionary.
     return results
 
 def generate_final_results_deduction_per_error(
@@ -149,35 +151,28 @@ def generate_final_results_deduction_per_error(
     Returns:
     dict: final results for dumping as yaml
     """
-    results = {
-        "points": max(max_points - len(mistakes*deduction_per_error), 0),
-        "max_points": max_points,
-        "mistakes": mistakes
-    }
+    return _generate_final_results(
+        mistakes,
+        max(max_points - len(mistakes*deduction_per_error), 0),
+        max_points
+    )
 
-    return results
-
-def generate_final_results_points_per_test(
-        mistakes, test_count, points_per_test):
+def _generate_final_results(mistakes, points, max_points):
     """
-    Generates a results dictionary as defined in d2g_procedure.md in the
-    documentation for the points per test strategy that grants a defined
-    number of points for each correct test.
-
+    Default function for generating the final results.
+    
     Params:
-    mistakes          (list): List of mistakes as defined in
-                              d2g_procedure.md in the documentation.
-    test_count       (tuple): Tuple (all_tests, failed_tests) containing
-                              the number of tests executed and the number of
-                              tests that failed.
-    points_per_test (number): Points awarded per correct test.
+    mistakes     (list): List of mistakes as defined in
+                         d2g_procedure.md in the documentation.
+    points     (number): Number of points for all correct answers.
+    max_points (number): Maximum number of points that can be achieved.
     
     Returns:
     dict: final results for dumping as yaml
     """
     results = {
-        "points": (test_count[0]-test_count[1]) * points_per_test,
-        "max_points": test_count[0] * points_per_test,
+        "points": points,
+        "max_points": max_points,
         "mistakes": mistakes
     }
 


### PR DESCRIPTION
Closes #94.

Mit der Angabe `_{0-9}p` kann jetzt die genaue Anzahl an Punkten, die ein Unittest gibt, angegeben werden. Der PR räumt im gleichen Zug auch `metric_utils.py` auf, da wir es da ein wenig einfacher machen können mit der Änderung.