### PR TITLE
[D2G] create_mistake-Funktion in metric_utils hinzugefügt

### DIFF
--- a/scripts/metrics/javadoc_eval.py
+++ b/scripts/metrics/javadoc_eval.py
@@ -107,12 +107,10 @@ def _convert_errors_to_mistakes(errors, max_points, deduction_per_error):
         if isinstance(error, str):
             error = errors[error]
 
-        mistakes.append({
-            "deduction": deduction_per_error if error_count < max_points \
-                else 0,
-            "description": "%s: %s\n\t%s" % (error["type"], error["message"],
-                error["source"])
-        })
+        mistakes.append(metric_utils.create_mistake(
+            deduction_per_error if error_count < max_points else 0,
+            "%s: %s\n\t%s" % (error["type"], error["message"], error["source"])
+        ))
         error_count += deduction_per_error
 
     return mistakes

--- a/scripts/metrics/junit_eval.py
+++ b/scripts/metrics/junit_eval.py
@@ -74,10 +74,8 @@ def _summarize_mistakes(data, points_per_test):
             if testcase.tag == "testcase" and len(testcase) > 0:
                 description = "%s::%s: %s" % (root.attrib["name"], \
                     testcase.attrib["name"], testcase[0].attrib["message"])
-                mistakes.append({
-                    "deduction": points_per_test,
-                    "description": description
-                })
+                mistakes.append(metric_utils.create_mistake(points_per_test,
+                                                            description))
 
     return mistakes
 

--- a/scripts/metrics/metric_utils.py
+++ b/scripts/metrics/metric_utils.py
@@ -102,6 +102,25 @@ def load_yaml(path, usage_text=None):
         print(usage_text)
         exit(-1)
 
+def create_mistake(deduction, description):
+    """
+    Creates a new mistake object containing the deduction points and a
+    description of the error.
+
+    Params:
+    deduction   (number): Number of points that are deducted from the overall
+                          because of the mistake.
+    description (string): Description of the mistake containing information
+                          about what is wrong and where the mistake is.
+
+    Returns:
+    dict: mistake object containing the summary of the mistake.
+    """
+    return {
+        "deduction": deduction,
+        "description": description
+    }
+
 def generate_final_results_all_or_nothing(result, points, error_description):
     """
     Generates a results dictionary as defined in d2g_procedure.md in the
@@ -124,12 +143,7 @@ def generate_final_results_all_or_nothing(result, points, error_description):
     }
 
     if not result:
-        results["mistakes"] = [
-            {
-                "deduction": points,
-                "description": error_description
-            }
-        ]
+        results["mistakes"] = [create_mistake(points, error_description)]
 
     return results
 


### PR DESCRIPTION
Fügt eine `create_mistake`-Funktion in `metric_utils.py` hinzu, damit die Strings für `deduction` und `description` nur an einem Ort stehen und die Wahrscheinlichkeit für Schreibfehler geringer ist.