### PR TITLE
[D2G] Variante der Punktevergabe für die JUnit-Metrik hinzugefügt

### DIFF
--- a/scripts/metrics/metric_utils.py
+++ b/scripts/metrics/metric_utils.py
@@ -28,6 +28,23 @@ def print_usage(usage_text):
     if usage_text is not None:
         print(usage_text)
 
+def has_env_variable(key, taskname=None):
+    """
+    Combines taskname with key and checks if an environment variable with
+    the given name is defined.
+
+    Params:
+    key      (string): Key of the environment variable.
+    taskname (string): Optional taskname that is combined with the env key.
+
+    Returns:
+    bool: True when the environment variable exists.
+    """
+    if taskname is not None:
+        key = key % taskname.upper()
+
+    return key in os.environ
+
 def get_env_variable(key, taskname=None, usage_text=None):
     """
     Combines taskname with key and returns its corresponding environment

--- a/scripts/print_results_student.py
+++ b/scripts/print_results_student.py
@@ -118,7 +118,7 @@ def _print_deductions(results):
         for metric in results[task][1]["tests"]:
             if "mistakes" in metric[list(metric.keys())[0]]:
                 for mistake in metric[list(metric.keys())[0]]["mistakes"]:
-                    print("[%s:%s (-%d Punkt(e))] %s"
+                    print("[%s:%s (-%.2f Punkt(e))] %s"
                         % (task, list(metric.keys())[0], mistake["deduction"],
                         mistake["description"]))
 


### PR DESCRIPTION
Closes #95.

Fügt für die JUnit-Metrik eine optionale Angabe der Gesamtpunktzahl hinzu. Die tatsächliche vergebenen Punkte werden auf diese Punktzahl umgerechnet.

Da das Issue von Evaluieren spricht: Die Angabe der Gesamtpunktzahl ist optional. Wirkliche Nachteile habe ich beim Implementieren aber nicht gefunden. Einzig dass es für Aufgaben jetzt eine ziemlich krumme Punktzahl vergeben werden kann, ist wie ich finde nicht gerade schön. Aktuell werden die Punkte auf zwei Nachkommastellen gerundet.