### PR TITLE
[D2G] Metriken Dokumentation hinzugefügt

### DIFF
--- a/doc/metrics/codeformat.md
+++ b/doc/metrics/codeformat.md
@@ -1,3 +1,33 @@
 ---
 title: Codeformat-Metrik
 ---
+
+Über die Codeformat-Metrik kann geprüft werden, ob der Code korrekt formatiert ist. Dazu wird das Gradle `spotlessJavaCheck`-Target ausgeführt. Über den Rückgabewert wird ermittelt, ob der Code korrekt formatiert ist. Bei einer korrekten Formatierung wird eine über die Konfiguration definierte Punktzahl vergeben.
+
+Mit dem folgenden YAML-Code kann die Codeformat-Metrik einer Aufgabenstellung
+hinzugefügt werden:
+
+```yml
+metrics:
+- codeformat:
+    points: 2
+```
+
+- `points`: Gibt die Anzahl der zu vergebenden Punkte bei erfolgreicher
+  Ausführung an.
+
+Damit die Codeformat-Metrik ausgeführt werden kann, muss der
+`spotlessJavaCheck`-Task in der `build.gradle`-Datei korrekt konfiguriert sein.
+Im folgenden ist eine Beispielkonfiguration angegeben:
+
+```gradle
+plugins {
+    id 'com.diffplug.spotless' version '6.+'
+}
+
+spotless {
+    java {
+        googleJavaFormat().aosp().reflowLongStrings()
+    }
+}
+```

--- a/doc/metrics/codeformat.md
+++ b/doc/metrics/codeformat.md
@@ -1,0 +1,3 @@
+---
+title: Codeformat-Metrik
+---

--- a/doc/metrics/compile.md
+++ b/doc/metrics/compile.md
@@ -1,3 +1,21 @@
 ---
 title: Compile-Metrik
 ---
+
+Die Compile-Metrik überprüft, ob der Programmcode fehlerfrei kompiliert werden
+kann und vergibt bei korrekter Ausführung eine eindeutig vorgegebene Punktzahl.
+Die Kompilierung wird über Gradle die Kompilierung durchgeführt. Dazu muss im
+Gradle-Projekt die `compileJava`-Task definiert sein. Über den Rückgabewert
+wird ermittelt, ob das Kompilieren erfolgreich war.
+
+Mit dem folgenden YAML-Code kann die Compile-Metrik einer Aufgabenstellung
+hinzugefügt werden:
+
+```yml
+metrics:
+- compile:
+    points: 1
+```
+
+- `points`: Gibt die Anzahl der zu vergebenden Punkte bei erfolgreicher
+  Ausführung an.

--- a/doc/metrics/compile.md
+++ b/doc/metrics/compile.md
@@ -1,0 +1,3 @@
+---
+title: Compile-Metrik
+---

--- a/doc/metrics/javadoc.md
+++ b/doc/metrics/javadoc.md
@@ -1,3 +1,77 @@
 ---
 title: JavaDoc-Metrik
 ---
+
+Die JavaDoc-Metrik nutzt intern Checkstyle, um die korrekte Verwendung von JavaDoc zu prüfen. Dabei wird das Gradle `checkstyleMain`-Target ausgeführt. Über den Rückgabewert wird ermittelt, ob der Code korrekt formatiert ist. Bei einer korrekten Formatierung wird eine über die Konfiguration definierte Punktzahl vergeben. Dabei werden von einem vorgebenen Maximalwert für die Punkte je nach Anzahl der Fehler Punkte abgezogen. Bei der Konfiguration kann zwischen zwei verschiedenen Vergabevarianten gewählt werden. Zum einen kann für jeden Fehler ein Punkt abgezogen werden. Die zweite Variante erlaubt das Gruppieren der Fehlertypen und zieht nur beim ersten Auftauchen eines Fehlertypens einen Punkt ab.
+
+Mit dem folgenden YAML-Code kann die Codeformat-Metrik einer Aufgabenstellung
+hinzugefügt werden:
+
+```yml
+metrics:
+- javadoc:
+    max_points: 10
+    deduction_per_error: 1
+    group_errors: false
+```
+
+- `max_points`: Gibt die maximal erreichbare Punktzahl für diese Metrik an.
+- `deduction_per_error`: Gibt die Anzahl an Punkten, die pro Fehler abgezogen werden, an.
+- `group_errors`: Wählt zwischen den zwei Varianten für das Abziehen von Punkten bei Fehlern. Ist der Wert auf `true` gesetzt, dann werden pro Fehlertyp maximal ein mal Punkte abgezogen. Ansonsten werden für jeden Fehler die Punkte abgezogen.
+
+Damit die JavaDoc-Metrik ausgeführt werden kann, muss der
+`checkstyleMain`-Task in der `build.gradle`-Datei korrekt konfiguriert sein.
+Im folgenden ist eine Beispielkonfiguration angegeben:
+
+```gradle
+plugins {
+    id 'checkstyle'
+}
+
+checkstyle {
+    toolVersion = "10.2"
+    configFile = file(".config/checkstyle/javadoc.xml")
+    reportsDir = file("build/results/javadoc")
+}
+
+tasks.withType(Checkstyle) {
+    reports {
+        xml.required = true
+        html.required = false
+    }
+}
+```
+
+Des Weiteren muss im Projektpfad unter `.config/checkstyle/javadoc.xml` eine Konfiguration für Checkstyle vorhanden sein. Die folgende Beispielkonfiguration prüft alle für JavaDoc relevanten Angaben:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="severity" value="warning"/>
+
+    <module name="TreeWalker">
+        <module name="AtclauseOrder"/>
+        <module name="InvalidJavadocPosition"/>
+        <module name="JavadocBlockTagLocation"/>
+        <module name="JavadocContentLocation"/>
+        <module name="JavadocMethod"/>
+        <module name="JavadocMissingLeadingAsterisk"/>
+        <module name="JavadocMissingWhitespaceAfterAsterisk"/>
+        <module name="JavadocParagraph"/>
+        <module name="JavadocStyle"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="JavadocType"/>
+        <module name="JavadocVariable">
+            <property name="scope" value="public"/>
+        </module>
+        <module name="MissingDeprecated"/>
+        <module name="MissingJavadocMethod"/>
+        <module name="MissingJavadocType"/>
+        <module name="MissingOverride"/>
+        <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+    </module>
+</module>
+```

--- a/doc/metrics/javadoc.md
+++ b/doc/metrics/javadoc.md
@@ -1,0 +1,3 @@
+---
+title: JavaDoc-Metrik
+---

--- a/doc/metrics/junit.md
+++ b/doc/metrics/junit.md
@@ -32,11 +32,11 @@ metrics:
 Damit die JUnit-Metrik ausgeführt werden kann, muss der `test`-Task in der
 `build.gradle`-Datei korrekt konfiguriert sein. Der Pfad zum Speichern der
 Ergebnisse im XML-Format muss dabei `build/results/junit/xml` sein. Im
-folgenden ist eine Beispielkonfiguration angegeben.
+folgenden ist eine Beispielkonfiguration angegeben:
 
 ```gradle
 dependencies {
-    testImplementation `junit:junit:4.13.2`
+    testImplementation 'junit:junit:4.13.2'
 }
 
 test {

--- a/doc/metrics/junit.md
+++ b/doc/metrics/junit.md
@@ -1,0 +1,3 @@
+---
+title: JUnit-Metrik
+---

--- a/doc/metrics/junit.md
+++ b/doc/metrics/junit.md
@@ -1,3 +1,102 @@
 ---
 title: JUnit-Metrik
 ---
+
+Über die JUnit-Metrik können Java-Unittests ausgeführt und bewertet werden.
+Dabei wird das Gradle `test`-Target ausgeführt. Die JUnit-Metrik kann verwendet
+werden, ohne dass Anpassungen an den Tests notwendig sind. Dazu kann eine
+Standardpunktzahl für einzelne Tests als auch eine Gesamtpunktzahl angegeben
+werden. Mit Anpassungen am Java-Code der Tests ist es auch möglich, einzelnen
+Tests individuelle Punktzahlen zu geben. Des Weiteren können über diese Metrik
+CLI-Tests umgesetzt werden.
+
+Mit dem folgenden YAML-Code kann die JUnit-Metrik einer Aufgabenstellung
+hinzugefügt werden:
+
+```yml
+metrics:
+- junit:
+    default_points: 1
+    overall_points: 10
+```
+
+- `default_points`: Gibt die standardmäßige Punktzahl eines einzelnen Tests an.
+- `overall_points` (optional): Gibt die Gesamtpunktzahl an, die die
+  JUnit-Metrik bei null Fehlern gibt. Fehlt diese Angabe, dann wird die über
+  die Anzahl der Tests definierte Gesamtpunktzahl verwendet. Wenn über
+  `overall_points` eine Punktzahl angegeben ist, so wird diese Punktzahl auf
+  die gegebene Konfiguration umgerechnet. Achtung: Bei Verwendung dieser Option
+   kann es vorkommen, dass durch falsche Unittests eine "krumme" Punktzahl von
+   der Gesamtpunktzahl abgezogen wird.
+
+Damit die JUnit-Metrik ausgeführt werden kann, muss der `test`-Task in der
+`build.gradle`-Datei korrekt konfiguriert sein. Der Pfad zum Speichern der
+Ergebnisse im XML-Format muss dabei `build/results/junit/xml` sein. Im
+folgenden ist eine Beispielkonfiguration angegeben.
+
+```gradle
+dependencies {
+    testImplementation `junit:junit:4.13.2`
+}
+
+test {
+    useJUnit()
+    reports.junitXml.outputLocation = file("build/results/junit/xml")
+}
+```
+
+### Alternative Punktzahlen für einzelne Tests
+
+Einzelne Tests können alternativ zu der Standardpunktzahl eine eigene Punktzahl
+definieren. Dazu wird die zu vergebende Punktzahl am Ende des Namens der
+Testmethode definiert. Die Zahl wird dabei mit einem Unterstrich vom
+eigentlichen Namen. Am Ende der Punktzahl steht ein `P` oder `p`. Es ist nicht
+möglich, Kommazahlen anzugeben.
+
+```java
+    @Test
+    public void testDummyTest_2p() {
+        assertEquals(5, 2+3);
+    }
+```
+
+### Umsetzung von CLI-Tests
+
+CLI-Tests zum Prüfen der Konsolenausgabe werden auch über JUnit umgesetzt. In
+einer zusätzlichen Testklasse wird dafür vor jedem Test `System.out` auf einen
+neuen OutputStream gesetzt, der leicht ausgelesen werden kann. In den
+jeweiligen Testmethoden können wir dann die `main()`-Methode ausführen. Über
+den OutputStream wird die Ausgabe des Programms ausgelesen.
+
+```java
+// Der Übersichtlichkeit halber wird für CLI-Tests eine eigene Testklasse
+// genutzt.
+public class CliTest {
+
+    // In einem OutputStream werden die Konsolenausgaben gespeichert.
+    private ByteArrayOutputStream outStream;
+
+    @Before
+    public void before() {
+        // Vor jedem Test setzen wir einen neuen OutputStream für System.out.
+        outStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outStream));
+    }
+
+    @Test
+    public void testMessagePrintCorrect() {
+        // Im eigentlichen Test führen wir dann die main-Methode aus.
+        // Hier können wir u.A. auch `args` setzen.
+        Main.main(new String[]{});
+        // Über outStream.toString() können wir die Ausgabe erhalten.
+        assertEquals("Hello World!\n", outStream.toString());
+    }
+
+    @After
+    public void after()  {
+        // Und nach dem Test setzen wir auf den Default stdout Stream zurück.
+        System.setOut(new PrintStream(
+            new FileOutputStream(FileDescriptor.out)));
+    }
+}
+```

--- a/doc/metrics/readme.md
+++ b/doc/metrics/readme.md
@@ -2,6 +2,8 @@
 title: Metriken
 ---
 
+In diesem Kapitel wird beschrieben, wie die implementierten Metriken für eine Aufgabenstellungen genutzt werden können.
+
 ## Table of Contents
 
 1. [Codeformat](codeformat.md)

--- a/doc/metrics/readme.md
+++ b/doc/metrics/readme.md
@@ -1,0 +1,10 @@
+---
+title: Metriken
+---
+
+## Table of Contents
+
+1. [Codeformat](codeformat.md)
+2. [Compile](compile.md)
+3. [JavaDoc](javadoc.md)
+4. [JUnit](junit.md)


### PR DESCRIPTION
Fügt eine Beschreibung der Metriken im `doc`-Ordner hinzu.

Die Beschreibungen sind ausführlicher als das, was wir bisher in `design_document` haben. Ziel ist es zu beschreiben, was die Metrik macht, wie ich sie in einer `task.yml` hinzufügen kann (mit allen möglichen Optionen beschrieben) und wie Gradle konfiguriert sein muss. Im Falle von JUnit werden auch noch CLI-Tests und individuelle Punktzahlen für Tests beschrieben.