### PR TITLE
[Documentation] README erweitert

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to this project
+
+One of the best things about writing open source software is that
+people like you have the opportunity to give us feedback and ask questions or
+point out typos or find other errors or ambiguities in the text.
+
+## Questions, Bugs or Feature Requests
+
+You are welcome to open a new issue. After clicking on the "new issue" button,
+you will be offered a few issue templates. Please choose the appropriate template
+or select "Open a blank issue, if the templates do not fit.
+
+Please check first if your request is already addressed in other (open or closed)
+issues. Feel free to reopen matching closed issues for this purpose to enter your
+request there.
+
+## Pull Requests
+
+You are welcome to contribute via a pull request.
+
+Please **open an issue** first so that your contribution can be discussed
+beforehand.
+
+Work on your contribution in a feature branch. You will probably need to fork
+this repository to do this.
+
+Submit your contribution as a pull request from your feature branch to the
+`master` branch in this repository. Please make sure that your **feature
+branch starts on top of the current `master` branch**.
+
+After acceptance (i.e. merging your feature branch into the `master` branch),
+your contribution is automatically subject to the licence of this repository
+(CC-BY-SA-4.0).
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # Deploy-to-Grading
-Deploy to Grading is a toolchain for automated analysis and grading of programming tasks.
+
+Deploy-to-Grading (D2G) is a toolchain for automated analysis and grading of programming tasks. Contrary to other popular solutions, it uses freely available computing resources and is based on Git. Currently, only tools for grading Java assignments are implemented.
+
+
+## Usage
+
+For information on how to use D2G, take a look at the [documentation](doc/readme.md).
+
+
+## Contributing
+
+Questions, bug reports, feature requests and pull requests are very welcome.
+Please be sure to read the [contributor guidelines](CONTRIBUTING.md) before
+opening a new issue.
+
+
+## Language
+
+This project is intended as teaching material for German-language university
+courses and is therefore aimed at German-speaking students. Please keep in
+mind that the English documentation may therefore not be available or may be
+slightly out of date. If you have any questions, problems or suggestions, please
+feel free to contact us in English or German.
+
+
+## Credits
+
+This project is funded by [Stiftung für Innovation in der Hochschullehre](https://stiftung-hochschullehre.de)
+(["Freiraum 2022"](https://stiftung-hochschullehre.de/foerderung/freiraum2022/)).
+
+
+---
+
+## License
+
+This [work](https://github.com/Programmiermethoden/Deploy-to-Grading) by
+[André Kirsch](https://github.com/AKirsch1),
+[Carsten Gips](https://github.com/cagix), and
+[contributors](https://github.com/Programmiermethoden/Deploy-to-Grading/graphs/contributors)
+is licensed under [CC-BY-SA-4.0](LICENSE.md).
+

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -1,0 +1,27 @@
+# Documentation on Deploy-to-Grading
+
+## Local usage
+
+D2G can be run on any Linux operating system that comes with Bash and Python 3. To execute D2G, make sure that you are in an assignment folder, that contains an `assignment.yml` file. Furthermore, you need to set the `D2G_PATH` environment variable to the root directory of your cloned D2G repository. Execute the following command to run D2G:
+
+```bash
+$D2G_PATH/scripts/deploy_to_grading.py
+```
+
+## Execution as a CI/CD-Pipeline
+
+You can use D2G as a CI/CD-Pipeline by adding a GitHub Workflow to your repository. The following listing shows an example configuration for such a pipeline:
+
+```
+name: Deploy-to-Grading
+on:
+  workflow_dispatch:
+  
+jobs:
+  deploy-to-grading:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: programmiermethoden/deploy-to-grading@master
+```
+


### PR DESCRIPTION
Fügt im Hinblick auf den ABP-Workshop der README-Datei ein paar mehr Informationen hinzu. Des Weiteren habe ich noch eine Datei `CONTRIBUTING.md` und eine `readme.md` im `doc`-Ordner hinzugefügt.

Damit sollte das Repository ein bisschen interessanter aussehen, falls sich jemand aufgrund des Workshops das Repository anschauen sollte.