### PR TITLE
[Documentation] Vereinheitlicht Sprache im doc-Ordner

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Deploy-to-Grading (D2G) is a toolchain for automated analysis and grading of pro
 
 ## Usage
 
-For information on how to use D2G, take a look at the [documentation](doc/readme.md).
+For information on how to use D2G, take a look at the [documentation (in german)](doc/readme.md).
 
 
 ## Contributing

--- a/doc/design_document/readme.md
+++ b/doc/design_document/readme.md
@@ -4,7 +4,7 @@ title: D2G-Designdokument
 
 In diesem Designdokument wird ein Konzept vorgestellt, durch das wir den bisherigen Abgabeprozess im Modul Programmiermethoden des Studiengangs Informatik an der Hochschule Bielefeld mit einer automatischen Bewertung verknüpfen möchten. Studierende bearbeiten die Aufgaben lokal, laden ihre Lösungen in ihr Team-Repository auf einem Git-Server und erstellen zur Abgabe einen Pull Request. Commits zu diesem Pull Request sollen automatisch eine GitHub Action ausführen, die den Bewertungsprozess durchführt. Studierende können in der Ausgabe der GitHub Action ihre erreichte Punktzahl einsehen. Im Gegensatz zu anderen automatischen Bewertungssystemen nutzen wir keine eigene Serverstruktur und lehren gleichzeitig den Umgang mit Git und Free Open Source Software (FOSS). Daher ist unser automatisches Bewertungssystem eher für fortgeschrittenere Programmierkurse ab dem zweiten Semester geeignet.
 
-## Table of Contents
+## Inhaltsverzeichnis
 
 1. [Ablauf des Deploy-to-Grading](d2g_procedure.md)
 2. [Testmetriken](metrics.md)
@@ -13,6 +13,7 @@ In diesem Designdokument wird ein Konzept vorgestellt, durch das wir den bisheri
 
 
 ### Weitere outdated Issues
+
 - [Deploy-to-Grading konzipieren #10](https://github.com/Programmiermethoden/Deploy-to-Grading/issues/10)
 - [Deploy-to-Grading How to #11](https://github.com/Programmiermethoden/Deploy-to-Grading/issues/11)
 - [Build Script für alle Task #15](https://github.com/Programmiermethoden/Deploy-to-Grading/issues/15)

--- a/doc/design_document/repository_structure/readme.md
+++ b/doc/design_document/repository_structure/readme.md
@@ -40,7 +40,7 @@ Studierenden wird pro Praktikumseinheit eine ausgewählte Liste an Aufgaben gest
 
 *Anmerkung 2: @AMatutat hat mir mittlerweile gesagt, dass ihr im letzten Semester den Studis alle Aufgaben auf einmal zur Verfügung gestellt habt.*
 
-## Table of Contents
+## Inhaltsverzeichnis
 
 1. [Dateistruktur von Aufgaben](file_structure.md)
 2. [Definition von Konfigurationsdateien für Aufgabenblatt- und Aufgabendefinition](file_structure.md)

--- a/doc/metrics/readme.md
+++ b/doc/metrics/readme.md
@@ -4,7 +4,7 @@ title: Metriken
 
 In diesem Kapitel wird beschrieben, wie die implementierten Metriken für eine Aufgabenstellungen genutzt werden können.
 
-## Table of Contents
+## Inhaltsverzeichnis
 
 1. [Codeformat](codeformat.md)
 2. [Compile](compile.md)

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -1,31 +1,22 @@
-# Documentation on Deploy-to-Grading
+---
+title: Deploy-to-Grading Dokumentation
+---
 
-## Local usage
+Deploy-to-Grading (D2G) ist eine Toolchain zur automatischen Analyse und Bewertung von Programmieraufgaben. Im Gegensatz zu anderen populären Lösungen nutzt es frei verfügbare Rechenkapazität (GitHub Runner) und basiert auf Git. Aktuell sind nur Tools zur Bewertung von Java-Programmieraufgaben implementiert.
 
-D2G can be run on any Linux operating system that comes with Bash and Python 3. To execute D2G, make sure that you are in an assignment folder, that contains an `assignment.yml` file. Furthermore, you need to set the `D2G_PATH` environment variable to the root directory of your cloned D2G repository. Execute the following command to run D2G:
+## Lokale Ausführung
+
+D2G kann lokal auf jedem Linux Betriebssystem ausgeführt werden, auf dem Bash und Python 3 zur Verfügung stehen. Um D2G auszuführen, muss sichergestellt werden, dass man sich in einem Ordner befindet, der eine `assignment.yml`-Datei enthält. Des Weiteren muss die `D2G_PATH`-Umgebungsvariable einen Pfad zum Hauptverzeichnis des geklonten D2G-Repositorys enthalten. Dazu muss der Befehl `export D2G_PATH=/home/{USER}/Deploy-to-Grading` ausgeführt werden. Sollte das D2G-Repository nicht im `Home`-Verzeichnis des Nutzers liegen, muss der Pfad entsprechend angepasst werden. Zum Ausführen des Deploy-to-Grading muss der folgende Befehl ausgeführt werden:
 
 ```bash
 $D2G_PATH/scripts/deploy_to_grading.py
 ```
 
-## Execution as a CI/CD-Pipeline
+## Ausführung als CI/CD-Pipeline
 
-You can use D2G as a CI/CD-Pipeline by adding a GitHub Workflow to your repository. The following listing shows an example configuration for such a pipeline:
+D2G kann auch als GitHub Workflow in ein Repository eingebunden werden, damit sie automatisch ausgeführt wird. Dazu muss der [Anleitung zum Erstellen eines Aufgabenrepositorys](create_tasks_repository.md) gefolgt werden.
 
-```
-name: Deploy-to-Grading
-on:
-  workflow_dispatch:
-  
-jobs:
-  deploy-to-grading:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: programmiermethoden/deploy-to-grading@master
-```
-
-## Table of Contents
+## Inhaltsverzeichnis
 
 1. [Skripte für Lehrende](teacher_scripts.md)
 2. [Aufgabenrepository erstellen](create_tasks_repository.md)

--- a/doc/related_work/readme.md
+++ b/doc/related_work/readme.md
@@ -47,7 +47,7 @@ Durch die folgenden Punkte können wir uns von anderen AutoGradern abgrenzen:
 * Wegen des Git-Workflows können wir kein ProFormA 2.0 verwenden
   * Das ist eher eine Einschränkung als Abgrenzung. Aber im Hinblick auf ABP 2023 relevant
 
-## Table of Contents
+## Inhaltsverzeichnis
 
 1. [Konferenzliste](https://github.com/Programmiermethoden/Dungeon/blob/master/doc/related_work/conferences.md)
 2. [Automatische Bewertungssysteme](autograder/readme.md)


### PR DESCRIPTION
Fixes #125.

- Übersetzt `doc/readme.md` auf Deutsch
- Ändert Überschrift `Table of contents` in allen README-Dateien im `doc`-Ordner auf `Inhaltsverzeichnis`
- Fügt Hinweis in root-README hinzu, das der Dokumentationsordner auf Deutsch sit