### PR TITLE
[ORG] set cagix as global owner, archive project (30.11.2023)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # global owner
-* @Programmiermethoden/dungeon
+* @cagix


### PR DESCRIPTION
Macht @cagix zum globalen code owner.